### PR TITLE
pkg/META: Add requirement for Nocrypto

### DIFF
--- a/pkg/META
+++ b/pkg/META
@@ -1,6 +1,6 @@
 version = "%%VERSION_NUM%%"
 description = "Salsa20 functions in pure OCaml"
-requires = "salsa20-core"
+requires = "salsa20-core nocrypto"
 archive(byte) = "salsa20.cma"
 archive(native) = "salsa20.cmxa"
 plugin(byte) = "salsa20.cma"


### PR DESCRIPTION
It wasn't linking it before...

It is used here:
```
salsa20.ml:    Nocrypto.Uncommon.Cs.xor_into state.buffer buffer count;
```